### PR TITLE
Implement Phase 3 sentiment analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,8 @@ mypy==1.8.0
 
 # Documentation
 sphinx==7.2.6
+
+# Phase 3: Sentiment Analysis
+transformers==4.36.2
+nltk==3.8.1
+emoji==2.8.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,8 +8,9 @@ __author__ = 'MakeSenseOfIt Team'
 __email__ = 'contact@makesentsofit.com'
 
 # Package metadata
-__all__ = ['Config', 'setup_logging', 'get_logger']
+__all__ = ['Config', 'setup_logging', 'get_logger', 'SentimentAnalyzer']
 
 # Import main components for easier access
 from .config import Config
 from .logger import setup_logging, get_logger
+from .sentiment import SentimentAnalyzer

--- a/src/sentiment/__init__.py
+++ b/src/sentiment/__init__.py
@@ -1,0 +1,6 @@
+"""Sentiment analysis package."""
+
+from .analyzer import SentimentAnalyzer
+from .preprocessor import TextPreprocessor
+
+__all__ = ["SentimentAnalyzer", "TextPreprocessor"]

--- a/src/sentiment/analyzer.py
+++ b/src/sentiment/analyzer.py
@@ -1,0 +1,98 @@
+"""Sentiment analysis utilities using transformers with VADER fallback."""
+from __future__ import annotations
+
+import logging
+from typing import List, Dict
+
+from transformers import pipeline
+from nltk.sentiment.vader import SentimentIntensityAnalyzer
+import nltk
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+
+from .preprocessor import TextPreprocessor
+
+logger = logging.getLogger(__name__)
+
+class SentimentAnalyzer:
+    """Analyze sentiment of text or posts."""
+
+    def __init__(self, model_name: str = "cardiffnlp/twitter-roberta-base-sentiment-latest"):
+        self.model_name = model_name
+        self.preprocessor = TextPreprocessor()
+
+        # Try to initialize transformer model
+        try:
+            device = 0 if torch and hasattr(torch, 'cuda') and torch.cuda.is_available() else -1
+            self.transformer = pipeline(
+                "sentiment-analysis",
+                model=model_name,
+                device=device,
+                truncation=True,
+                max_length=512,
+            )
+            self.transformer_available = True
+            logger.info("Loaded transformer model: %s", model_name)
+        except Exception as exc:  # pragma: no cover - depends on environment
+            logger.warning("Could not load transformer model: %s", exc)
+            self.transformer_available = False
+            self.transformer = None
+
+        # Ensure VADER resources
+        try:
+            nltk.data.find("sentiment/vader_lexicon.zip")
+        except LookupError:
+            nltk.download("vader_lexicon", quiet=True)
+
+        self.vader = SentimentIntensityAnalyzer()
+        self.cache: Dict[str, Dict] = {}
+
+    def analyze_batch(self, texts: List[str]) -> List[Dict]:
+        """Analyze a batch of texts."""
+        processed = [self.preprocessor.clean(t) for t in texts]
+
+        if self.transformer_available:
+            try:
+                preds = self.transformer(processed)
+                return [
+                    {
+                        "label": p["label"],
+                        "score": p["score"],
+                        "method": "transformer",
+                        "original_text": t[:200],
+                    }
+                    for t, p in zip(texts, preds)
+                ]
+            except Exception as exc:  # pragma: no cover - network/model issues
+                logger.error("Transformer batch processing failed: %s", exc)
+
+        return [self._analyze_with_vader(t) for t in texts]
+
+    def _analyze_with_vader(self, text: str) -> Dict:
+        """Analyze a single text using VADER."""
+        scores = self.vader.polarity_scores(text)
+        compound = scores["compound"]
+        if compound >= 0.05:
+            label = "POSITIVE"
+        elif compound <= -0.05:
+            label = "NEGATIVE"
+        else:
+            label = "NEUTRAL"
+        return {
+            "label": label,
+            "score": abs(compound),
+            "method": "vader",
+            "compound": compound,
+            "original_text": text[:200],
+            "details": scores,
+        }
+
+    def analyze_posts(self, posts: List["Post"]) -> List["Post"]:
+        """Attach sentiment to Post objects."""
+        texts = [f"{p.title} {p.content}" if getattr(p, "title", None) else p.content for p in posts]
+        sentiments = self.analyze_batch(texts)
+        for post, sent in zip(posts, sentiments):
+            post.sentiment = sent
+        return posts

--- a/src/sentiment/models.py
+++ b/src/sentiment/models.py
@@ -1,0 +1,22 @@
+"""Helper for loading transformer sentiment models."""
+from transformers import pipeline
+import torch
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_model(model_name: str = "cardiffnlp/twitter-roberta-base-sentiment-latest"):
+    """Load a sentiment analysis pipeline."""
+    try:
+        device = 0 if torch.cuda.is_available() else -1
+        return pipeline(
+            "sentiment-analysis",
+            model=model_name,
+            device=device,
+            truncation=True,
+            max_length=512,
+        )
+    except Exception as exc:
+        logger.warning("Failed to load sentiment model %s: %s", model_name, exc)
+        raise

--- a/src/sentiment/preprocessor.py
+++ b/src/sentiment/preprocessor.py
@@ -1,0 +1,49 @@
+"""Text preprocessing utilities for sentiment analysis."""
+from typing import Dict
+import re
+import emoji
+
+class TextPreprocessor:
+    """Preprocess text for sentiment analysis."""
+
+    def __init__(self) -> None:
+        self.url_pattern = re.compile(r"https?://\S+|www\.\S+")
+        self.mention_pattern = re.compile(r"@\w+")
+        self.hashtag_pattern = re.compile(r"#(\w+)")
+        self.whitespace_pattern = re.compile(r"\s+")
+
+    def clean(self, text: str) -> str:
+        """Clean text for sentiment analysis."""
+        if not text:
+            return ""
+
+        # Convert emojis to text
+        text = emoji.demojize(text, delimiters=(" ", " "))
+
+        # Remove URLs
+        text = self.url_pattern.sub("", text)
+
+        # Keep mentions but drop '@'
+        text = self.mention_pattern.sub(lambda m: m.group()[1:], text)
+
+        # Keep hashtags but drop '#'
+        text = self.hashtag_pattern.sub(r"\1", text)
+
+        # Normalize whitespace
+        text = self.whitespace_pattern.sub(" ", text)
+        text = text.strip()
+        return text
+
+    def extract_features(self, text: str) -> Dict:
+        """Extract simple textual features."""
+        return {
+            "has_urls": bool(self.url_pattern.search(text)),
+            "num_mentions": len(self.mention_pattern.findall(text)),
+            "num_hashtags": len(self.hashtag_pattern.findall(text)),
+            "num_emojis": len([c for c in text if c in emoji.EMOJI_DATA]),
+            "text_length": len(text),
+            "num_words": len(text.split()),
+            "exclamation_marks": text.count("!"),
+            "question_marks": text.count("?"),
+            "all_caps_ratio": sum(1 for c in text if c.isupper()) / max(len(text), 1),
+        }

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,53 @@
+"""Tests for sentiment analysis functionality."""
+from unittest.mock import patch
+
+from src.sentiment.analyzer import SentimentAnalyzer
+from src.sentiment.preprocessor import TextPreprocessor
+
+
+def test_preprocessor():
+    preprocessor = TextPreprocessor()
+
+    text = "Check out https://example.com for more"
+    cleaned = preprocessor.clean(text)
+    assert "https://" not in cleaned
+
+    text = "@user1 @user2 hello"
+    cleaned = preprocessor.clean(text)
+    assert "user1" in cleaned
+    assert "@" not in cleaned
+
+    text = "#Python #Programming is fun"
+    cleaned = preprocessor.clean(text)
+    assert "Python Programming" in cleaned
+    assert "#" not in cleaned
+
+
+@patch("src.sentiment.analyzer.pipeline")
+def test_sentiment_analyzer(mock_pipeline):
+    mock_pipeline.return_value = lambda texts: [
+        {"label": "POSITIVE", "score": 0.9} for _ in texts
+    ]
+    analyzer = SentimentAnalyzer()
+
+    texts = [
+        "I love this! It's amazing!",
+        "This is terrible and awful.",
+        "It's okay, nothing special.",
+    ]
+
+    results = analyzer.analyze_batch(texts)
+
+    assert len(results) == 3
+    assert results[0]["label"] == "POSITIVE"
+    assert results[1]["label"] == "POSITIVE"  # mocked
+    assert results[2]["label"] == "POSITIVE"
+
+
+def test_vader_fallback():
+    analyzer = SentimentAnalyzer()
+    result = analyzer._analyze_with_vader("This is fantastic!")
+
+    assert result["method"] == "vader"
+    assert result["label"] == "POSITIVE"
+    assert "compound" in result


### PR DESCRIPTION
## Summary
- implement sentiment analysis package with transformer/VADER approach
- add TextPreprocessor and SentimentAnalyzer
- integrate sentiment analysis step in CLI workflow
- include sentiment analysis requirements
- provide tests for sentiment functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b730078908324885b573fb8b360c9

## Summary by Sourcery

Add a new sentiment analysis phase to the CLI pipeline, backed by a transformer model with a VADER fallback, update dependencies, and include unit tests for the new functionality.

New Features:
- Implement Phase 3 sentiment analysis with a hybrid transformer-based and VADER fallback workflow in the CLI
- Introduce a sentiment analysis package including SentimentAnalyzer, TextPreprocessor, and model loader

Enhancements:
- Summarize sentiment label counts and export results as JSON output

Build:
- Add transformers and nltk to project requirements for sentiment analysis

Tests:
- Add unit tests for text preprocessing, transformer-based batch analysis, and VADER fallback logic