### PR TITLE
Fix plugin conflict for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short
+addopts = -v --tb=short -p no:pytest_asyncio


### PR DESCRIPTION
## Summary
- disable `pytest_asyncio` plugin in `pytest.ini` to prevent conflicts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2e210f5c8324a1043572e5bbcdf0

## Summary by Sourcery

Bug Fixes:
- Remove `-v --tb=short` addopts entry from pytest.ini to disable pytest_asyncio and avoid plugin conflicts