### PR TITLE
Fix Phase 5 export handling and tests

### DIFF
--- a/src/export/formatter.py
+++ b/src/export/formatter.py
@@ -143,9 +143,14 @@ class DataFormatter:
             
             posts_data.append(post_data)
         
+        # Always return a posts DataFrame even if empty so downstream
+        # processing can rely on its existence. This mirrors the behaviour
+        # expected by the tests for empty contexts.
+        dataframes['posts'] = pd.DataFrame(posts_data)
         if posts_data:
-            dataframes['posts'] = pd.DataFrame(posts_data)
             logger.debug(f"Created posts DataFrame with {len(posts_data)} rows")
+        else:
+            logger.debug("Created empty posts DataFrame")
         
         # 2. Daily Statistics DataFrame
         stats = context.get('statistics', {})


### PR DESCRIPTION
## Summary
- ensure CSV exports always include a posts dataframe
- expose temp_output_dir fixture for all export tests
- finish unicode handling integration test

## Testing
- `pytest -q`
- `python dev_examples/phase4_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_685c572ad01483249529bdacf5dd8296