### PR TITLE
Specify PyTorch for sentiment pipeline

### DIFF
--- a/src/sentiment/analyzer.py
+++ b/src/sentiment/analyzer.py
@@ -57,6 +57,7 @@ class SentimentAnalyzer:
                 device=device,
                 truncation=True,
                 max_length=512,
+                framework="pt",
             )
             self.transformer_available = True
             logger.info("Loaded transformer model: %s", self.model_name)


### PR DESCRIPTION
## Summary
- ensure transformer-based sentiment analysis only uses PyTorch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6ac56654832483eef4c8d087ff79

## Summary by Sourcery

Enhancements:
- Add framework="pt" argument to the Huggingface pipeline call to enforce PyTorch usage.