### PR TITLE
Fix transformer init on macOS

### DIFF
--- a/src/sentiment/analyzer.py
+++ b/src/sentiment/analyzer.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import logging
+import os
+
+# Avoid importing TensorFlow in transformers which can crash on some platforms
+os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORTS", "1")
 from typing import List, Dict
 
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
@@ -48,6 +52,8 @@ class SentimentAnalyzer:
         self._transformer_init_attempted = True
         try:
             # Lazy import of transformers - only import when needed
+            # Avoid importing TensorFlow to prevent Metal backend issues on macOS
+            os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORTS", "1")
             from transformers import pipeline as tf_pipeline
             
             device = 0 if torch and hasattr(torch, 'cuda') and torch.cuda.is_available() else -1

--- a/src/sentiment/models.py
+++ b/src/sentiment/models.py
@@ -1,4 +1,5 @@
 """Helper for loading transformer sentiment models."""
+import os
 from transformers import pipeline
 import torch
 import logging
@@ -10,6 +11,7 @@ def load_model(model_name: str = "cardiffnlp/twitter-roberta-base-sentiment-late
     """Load a sentiment analysis pipeline."""
     try:
         device = 0 if torch.cuda.is_available() else -1
+        os.environ.setdefault("TRANSFORMERS_NO_TF_IMPORTS", "1")
         return pipeline(
             "sentiment-analysis",
             model=model_name,


### PR DESCRIPTION
## Summary
- prevent TensorFlow imports to avoid Metal backend crash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6bc575488324a5a26f94c9b5bf85

## Summary by Sourcery

Bug Fixes:
- Set TRANSFORMERS_NO_TF_IMPORTS to "1" before importing transformers in analyzer and model loader to block TensorFlow imports on macOS.