### PR TITLE
Fallback to TextBlob+VADER when no OpenAI key

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,7 +156,6 @@ Create a `config.json` file for default settings:
     "twitter": 50,
     "reddit": 60
   },
-  "sentiment_model": "cardiffnlp/twitter-roberta-base-sentiment-latest",
   "visualization_style": "dark",
   "output_directory": "./output",
   "cache_directory": "./cache"
@@ -299,7 +298,6 @@ class Config:
         'twitter': 50,
         'reddit': 60
     })
-    sentiment_model: str = 'cardiffnlp/twitter-roberta-base-sentiment-latest'
     output_directory: str = './output'
     cache_directory: str = './cache'
     
@@ -824,7 +822,7 @@ def test_twitter_scraper():
 
 ### Objectives
 - Integrate transformer models
-- Implement VADER fallback
+ - Implement VADER/TextBlob fallback
 - Batch processing for efficiency
 - Confidence scoring
 
@@ -1030,7 +1028,7 @@ from src.sentiment.analyzer import SentimentAnalyzer
 
 # Analyze sentiment
 click.echo("🧠 Analyzing sentiment...")
-analyzer = SentimentAnalyzer(cfg.sentiment_model)
+analyzer = SentimentAnalyzer()
 
 # Process in batches for efficiency
 batch_size = 100
@@ -1102,20 +1100,20 @@ def test_sentiment_analyzer():
     assert results[2]['label'] in ['NEUTRAL', 'NEGATIVE', 'POSITIVE']  # Model dependent
     
 def test_vader_fallback():
-    """Test VADER fallback."""
+    """Test VADER/TextBlob fallback."""
     analyzer = SentimentAnalyzer()
     
     # Force VADER
-    result = analyzer._analyze_with_vader("This is fantastic!")
-    
-    assert result['method'] == 'vader'
+    result = analyzer._analyze_with_combined("This is fantastic!")
+
+    assert result['method'] == 'vader_textblob'
     assert result['label'] == 'POSITIVE'
     assert 'compound' in result
 ```
 
 ### Exit Criteria for Phase 3
 - [ ] Transformer model loads and works
-- [ ] VADER fallback functions correctly
+- [ ] VADER/TextBlob fallback functions correctly
 - [ ] Batch processing improves performance
 - [ ] Sentiment attached to all posts
 - [ ] All Phase 3 tests pass
@@ -3062,7 +3060,7 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
     # Phase 3: Sentiment Analysis  
     with memory_tracker("Sentiment Analysis"):
         click.echo(f"\n🧠 Analyzing sentiment for {len(all_posts)} posts...")
-        analyzer = SentimentAnalyzer(cfg.sentiment_model)
+        analyzer = SentimentAnalyzer()
         
         # Process in batches with progress tracking
         batch_size = 100

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Important keys are:
 - `output_formats` – formats to export (`json`, `csv`, `html`)
 - `output_prefix` – prefix for generated files
 - `visualize` – enable image and interactive chart generation
-- `openai_api_key` – optional key for using ChatGPT sentiment analysis
+- `openai_api_key` – optional key for using ChatGPT sentiment analysis. When not provided, the tool falls back to a built-in VADER/TextBlob approach.
 
 Any command line flags override the values loaded from the configuration file.
 

--- a/config.json
+++ b/config.json
@@ -14,7 +14,6 @@
     "client_secret": "iujrYggS49E1NXf4ceFRSXdxzbQ0mg",
     "user_agent": "MakeSenseOfIt/1.0"
   },
-  "sentiment_model": "cardiffnlp/twitter-roberta-base-sentiment-latest",
   "visualization_style": "dark",
   "output_directory": "./output",
   "cache_directory": "./cache",

--- a/config.json.example
+++ b/config.json.example
@@ -14,7 +14,6 @@
     "client_secret": "reddit_client_secret",
     "user_agent": "MakeSenseOfIt/1.0"
   },
-  "sentiment_model": "cardiffnlp/twitter-roberta-base-sentiment-latest",
   "visualization_style": "dark",
   "output_directory": "./output",
   "cache_directory": "./cache",

--- a/makesentsofit.py
+++ b/makesentsofit.py
@@ -133,7 +133,6 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
             print(f"  • Config file: {config or 'Using defaults'}")
             print(f"  • Output directory: {output_dir}")
             print(f"  • Cache directory: {cfg.cache_directory}")
-            print(f"  • Sentiment model: {cfg.sentiment_model}")
             
             print(f"\n⚡ Rate Limits:")
             for platform in platform_list:
@@ -247,7 +246,7 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
             print("\n🧠 Starting Phase 3: Sentiment Analysis")
             print("="*50)
             
-            analyzer = SentimentAnalyzer(cfg.sentiment_model, cfg.openai_api_key)
+            analyzer = SentimentAnalyzer(cfg.openai_api_key)
             batch_size = cfg.batch_size
 
             print(f"Analyzing sentiment for {len(all_posts)} posts...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ sphinx==7.2.6
 transformers==4.36.2
 nltk==3.8.1
 emoji==2.8.0
+textblob==0.17.1
 
 # Phase 6: Visualization
 matplotlib==3.8.2

--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,6 @@ class Config:
         'twitter': 50,
         'reddit': 60
     })
-    sentiment_model: str = 'cardiffnlp/twitter-roberta-base-sentiment-latest'
     output_directory: str = './output'
     cache_directory: str = './cache'
     visualization_style: str = 'dark'
@@ -78,7 +77,6 @@ class Config:
         self.default_platforms = ['twitter', 'reddit']
         self.default_time_window = 30
         self.rate_limits = {'twitter': 50, 'reddit': 60}
-        self.sentiment_model = 'cardiffnlp/twitter-roberta-base-sentiment-latest'
         self.output_directory = './output'
         self.cache_directory = './cache'
         self.visualization_style = 'dark'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,6 @@ class TestConfig:
         assert config.default_time_window == 30
         assert 'twitter' in config.default_platforms
         assert 'reddit' in config.default_platforms
-        assert config.sentiment_model == 'cardiffnlp/twitter-roberta-base-sentiment-latest'
         assert config.output_directory == './output'
         assert config.cache_directory == './cache'
         assert config.batch_size == 100
@@ -89,7 +88,6 @@ class TestConfig:
         assert 'default_platforms' in config_dict
         assert 'rate_limits' in config_dict
         assert config_dict['default_time_window'] == 30
-        assert config_dict['sentiment_model'] == config.sentiment_model
     
     def test_config_save(self, temp_dir):
         """Test saving configuration."""

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -267,7 +267,7 @@ class TestDataAggregator:
         """Test temporal pattern analysis."""
         # Create posts at different times
         posts = []
-        base_time = datetime.now()
+        base_time = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
         
         # Morning posts
         for i in range(3):
@@ -409,7 +409,7 @@ class TestTimeSeriesAnalyzer:
     def test_daily_sentiment_aggregation(self):
         """Test daily sentiment aggregation."""
         posts = []
-        base_time = datetime.now()
+        base_time = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
         
         # Day 1: 2 positive, 1 negative
         for i in range(2):

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -32,12 +32,11 @@ def test_sentiment_analyzer_creation():
         assert analyzer is not None
         assert hasattr(analyzer, 'preprocessor')
         assert hasattr(analyzer, 'vader')
-        assert hasattr(analyzer, 'model_name')
         
         # Test VADER functionality directly (without triggering transformers)
-        result = analyzer._analyze_with_vader("This is fantastic!")
+        result = analyzer._analyze_with_combined("This is fantastic!")
         
-        assert result["method"] == "vader"
+        assert result["method"] == "vader_textblob"
         assert result["label"] == "POSITIVE"
         assert "compound" in result
         assert "score" in result
@@ -49,12 +48,12 @@ def test_sentiment_analyzer_creation():
 
 
 def test_vader_fallback():
-    """Test VADER functionality directly."""
+    """Test combined VADER/TextBlob analysis."""
     try:
         analyzer = SentimentAnalyzer()
-        result = analyzer._analyze_with_vader("This is fantastic!")
+        result = analyzer._analyze_with_combined("This is fantastic!")
 
-        assert result["method"] == "vader"
+        assert result["method"] == "vader_textblob"
         assert result["label"] == "POSITIVE"
         assert "compound" in result
         


### PR DESCRIPTION
## Summary
- remove configurable transformer model
- default to VADER/TextBlob sentiment when OpenAI key is missing
- update docs and example configs accordingly
- add TextBlob dependency
- fix flaky time series test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca867009c832499ed77848070f11c

## Summary by Sourcery

Remove configurable transformer model support and default to a combined VADER/TextBlob sentiment analysis fallback when no OpenAI key is available, while updating documentation, configs, and tests accordingly.

New Features:
- Introduce a combined VADER/TextBlob sentiment analysis fallback method for use when no OpenAI key or transformer model is available

Bug Fixes:
- Normalize test timestamps to eliminate flaky time-series tests

Enhancements:
- Simplify SentimentAnalyzer by removing transformer model configuration and lazy loading logic
- Handle OpenAI client initialization errors gracefully and fall back to the built-in analyzer

Build:
- Add TextBlob as a dependency in requirements.txt

Documentation:
- Remove transformer model settings from docs and examples and document the new VADER/TextBlob fallback behavior

Tests:
- Update sentiment tests to use the new combined fallback method and adjust temporal tests to use fixed midday timestamps