### PR TITLE
Enhance fallback sentiment and stopwords

### DIFF
--- a/src/visualization/wordcloud.py
+++ b/src/visualization/wordcloud.py
@@ -2,13 +2,21 @@ from wordcloud import WordCloud
 import matplotlib.pyplot as plt
 from typing import List
 import re
+import nltk
+from nltk.corpus import stopwords
 
 
 class WordCloudGenerator:
     """Generate word clouds from posts."""
 
     def __init__(self) -> None:
-        self.stopwords = {
+        """Initialize word cloud generator with extensive stopwords."""
+        try:
+            nltk.data.find("corpora/stopwords")
+        except LookupError:  # pragma: no cover - download once
+            nltk.download("stopwords", quiet=True)
+
+        self.stopwords = set(stopwords.words("english")) | {
             "the",
             "a",
             "an",
@@ -64,6 +72,8 @@ class WordCloudGenerator:
             "my",
             "your",
             "their",
+            "just",
+            "if",
         }
 
     def create_wordcloud(self, posts: List["Post"], output_path: str, sentiment_filter: str | None = None) -> None:

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -36,7 +36,7 @@ def test_sentiment_analyzer_creation():
         # Test VADER functionality directly (without triggering transformers)
         result = analyzer._analyze_with_combined("This is fantastic!")
         
-        assert result["method"] == "vader_textblob"
+        assert result["method"] == "comprehensive"
         assert result["label"] == "POSITIVE"
         assert "compound" in result
         assert "score" in result
@@ -53,7 +53,7 @@ def test_vader_fallback():
         analyzer = SentimentAnalyzer()
         result = analyzer._analyze_with_combined("This is fantastic!")
 
-        assert result["method"] == "vader_textblob"
+        assert result["method"] == "comprehensive"
         assert result["label"] == "POSITIVE"
         assert "compound" in result
         


### PR DESCRIPTION
## Summary
- expand stopword list for word clouds using NLTK stopwords
- add comprehensive sentiment analysis when OpenAI isn't used
- adjust tests for the new sentiment analysis method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cac996f6c8324b85aafc7f7590198