### PR TITLE
Add dashboard generation

### DIFF
--- a/makesentsofit.py
+++ b/makesentsofit.py
@@ -383,6 +383,7 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
                     WordCloudGenerator,
                     InteractiveChartGenerator,
                     UserSentimentNetworkAnalyzer,
+                    DashboardGenerator,
                 )
 
                 charts = ChartGenerator()
@@ -390,6 +391,7 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
                 wordcloud = WordCloudGenerator()
                 interactive = InteractiveChartGenerator()
                 user_network = UserSentimentNetworkAnalyzer()
+                dashboard = DashboardGenerator()
 
                 if export_context.get("time_series", {}).get("daily_sentiment"):
                     charts.sentiment_timeline(
@@ -450,6 +452,13 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
                         str(output_dir / f"{output}_3d_scatter.html"),
                     )
                     print("  ✓ Interactive visualizations")
+
+                dashboard.generate_dashboard(
+                    export_context["posts"],
+                    str(output_dir / f"{output}_dashboard.html"),
+                )
+                exported_files.append(Path(output_dir / f"{output}_dashboard.html"))
+                print("  ✓ Dashboard")
 
             print(f"\n✅ Phase 5 complete! Exported {len(exported_files)} files")
             print(f"📁 Output directory: {writer.output_dir.absolute()}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,5 @@ seaborn==0.13.2
 networkx==3.1
 wordcloud==1.9.2
 plotly==5.18.0
+dash==2.15.0
 openai==1.30.1

--- a/src/export/templates/dashboard.html
+++ b/src/export/templates/dashboard.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MakeSenseOfIt Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+</head>
+<body>
+<div class="container my-4">
+    <h1 class="mb-4">MakeSenseOfIt Dashboard</h1>
+
+    <h2>Subreddit / Topic Network</h2>
+    <div>{{ network_graph|safe }}</div>
+
+    <h2 class="mt-4">Sentiment Distribution</h2>
+    <div>{{ sentiment_graph|safe }}</div>
+
+    <h2 class="mt-4">Posts ({{ post_count }})</h2>
+    <div class="table-responsive">
+        {{ table_html|safe }}
+    </div>
+</div>
+<script>
+$(document).ready(function(){
+    $('table').DataTable();
+});
+</script>
+</body>
+</html>

--- a/src/export/writers.py
+++ b/src/export/writers.py
@@ -166,6 +166,22 @@ class ExportWriter:
         except Exception as e:
             logger.error(f"Failed to write HTML report: {e}")
             raise
+
+    def write_dashboard(self, html_content: str, filename_prefix: str) -> Path:
+        """Write already-rendered dashboard HTML to file."""
+        filepath = self.output_dir / f"{filename_prefix}_dashboard.html"
+        try:
+            logger.info(f"Writing dashboard to: {filepath}")
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(html_content)
+            file_size = filepath.stat().st_size
+            logger.info(
+                f"Wrote dashboard file: {filepath.name} ({self._format_file_size(file_size)})"
+            )
+            return filepath
+        except Exception as e:
+            logger.error(f"Failed to write dashboard: {e}")
+            raise
     
     def write_summary(self, context: Dict[str, Any], filename_prefix: str) -> Path:
         """

--- a/src/visualization/__init__.py
+++ b/src/visualization/__init__.py
@@ -5,6 +5,7 @@ from .network import NetworkGraphGenerator
 from .wordcloud import WordCloudGenerator
 from .interactive import InteractiveChartGenerator
 from .user_network import UserSentimentNetworkAnalyzer
+from .dashboard import DashboardGenerator
 
 __all__ = [
     "ChartGenerator",
@@ -12,4 +13,5 @@ __all__ = [
     "WordCloudGenerator",
     "InteractiveChartGenerator",
     "UserSentimentNetworkAnalyzer",
+    "DashboardGenerator",
 ]

--- a/src/visualization/dashboard.py
+++ b/src/visualization/dashboard.py
@@ -1,0 +1,120 @@
+import pandas as pd
+import networkx as nx
+import plotly.graph_objects as go
+from pathlib import Path
+from typing import List
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+class DashboardGenerator:
+    """Generate an interactive HTML dashboard for scraped posts."""
+
+    def __init__(self):
+        template_dir = Path(__file__).resolve().parent.parent / "export" / "templates"
+        self.env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
+
+    def _create_network_html(self, posts: List["Post"]) -> str:
+        """Create HTML for subreddit-topic network graph."""
+        G = nx.Graph()
+        for post in posts:
+            subreddit = post.metadata.get("subreddit", "unknown")
+            topic = getattr(post, "query", "unknown")
+            G.add_node(subreddit, node_type="subreddit")
+            G.add_node(topic, node_type="topic")
+            if G.has_edge(subreddit, topic):
+                G[subreddit][topic]["weight"] += 1
+            else:
+                G.add_edge(subreddit, topic, weight=1)
+
+        if len(G.nodes()) == 0:
+            return ""
+
+        pos = nx.spring_layout(G, k=1)
+        edge_x = []
+        edge_y = []
+        for edge in G.edges():
+            x0, y0 = pos[edge[0]]
+            x1, y1 = pos[edge[1]]
+            edge_x.extend([x0, x1, None])
+            edge_y.extend([y0, y1, None])
+        edge_trace = go.Scatter(
+            x=edge_x,
+            y=edge_y,
+            line=dict(width=0.5, color="#888"),
+            hoverinfo="none",
+            mode="lines",
+        )
+
+        node_x = []
+        node_y = []
+        text = []
+        for node in G.nodes():
+            x, y = pos[node]
+            node_x.append(x)
+            node_y.append(y)
+            text.append(node)
+        node_trace = go.Scatter(
+            x=node_x,
+            y=node_y,
+            mode="markers+text",
+            text=text,
+            textposition="bottom center",
+            hoverinfo="text",
+            marker=dict(size=12, color="lightblue", line=dict(width=1, color="darkblue")),
+        )
+
+        fig = go.Figure(data=[edge_trace, node_trace])
+        fig.update_layout(
+            title="Subreddit / Topic Network",
+            showlegend=False,
+            margin=dict(l=20, r=20, t=40, b=20),
+        )
+        return fig.to_html(include_plotlyjs="cdn", full_html=False)
+
+    def _create_sentiment_bar(self, df: pd.DataFrame) -> str:
+        counts = df["sentiment"].value_counts()
+        if counts.empty:
+            return ""
+        fig = go.Figure([
+            go.Bar(x=counts.index.tolist(), y=counts.values.tolist(), marker_color=["green", "red", "gray"])
+        ])
+        fig.update_layout(title="Sentiment Distribution", yaxis_title="Posts")
+        return fig.to_html(include_plotlyjs=False, full_html=False)
+
+    def generate_dashboard(self, posts: List["Post"], output_path: str) -> None:
+        """Generate dashboard HTML from posts."""
+        if not posts:
+            return
+        df_rows = []
+        for post in posts:
+            row = {
+                "author": post.author,
+                "subreddit": post.metadata.get("subreddit"),
+                "topic": getattr(post, "query", ""),
+                "sentiment": getattr(post, "sentiment", {}).get("label") if hasattr(post, "sentiment") else None,
+                "score": getattr(post, "sentiment", {}).get("score") if hasattr(post, "sentiment") else None,
+                "title": post.title,
+                "content": post.content,
+                "url": post.url,
+                "timestamp": post.timestamp,
+            }
+            df_rows.append(row)
+        df = pd.DataFrame(df_rows)
+        network_html = self._create_network_html(posts)
+        sentiment_bar = self._create_sentiment_bar(df)
+        table_html = df.to_html(classes="table table-striped", index=False, border=0)
+
+        template = self.env.get_template("dashboard.html")
+        html = template.render(
+            network_graph=network_html,
+            sentiment_graph=sentiment_bar,
+            table_html=table_html,
+            post_count=len(df),
+        )
+        output_file = Path(output_path)
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(html)
+        return None


### PR DESCRIPTION
## Summary
- create DashboardGenerator for interactive dashboard output
- provide dashboard template HTML
- export dashboard during visualization phase
- add dash dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d70a0b890832487a7b384449f6f2b

## Summary by Sourcery

Enable end-to-end dashboard generation by adding a DashboardGenerator component, integrating it into the export workflow, and persisting the result with a new writer method using a Jinja2 template

New Features:
- Introduce DashboardGenerator to assemble an interactive HTML dashboard with network graph, sentiment distribution, and posts table from scraped data

Enhancements:
- Add write_dashboard method to export writers to persist rendered dashboard HTML
- Integrate dashboard generation into the CLI visualization phase and include the output in exported files

Build:
- Add dash 2.15.0 to project dependencies