### PR TITLE
Add Streamlit dashboard & update Reddit scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ You can still pass flags to override configuration values:
 python3 makesentsofit.py --queries "test" --time 7 --visualize
 ```
 
+When visualization is enabled the tool now offers an **interactive Streamlit dashboard** that launches at the end of the run. The dashboard loads the generated analysis JSON and lets you explore the user–subreddit–topic network with modern filters and Plotly visuals.
+
+```bash
+python3 makesentsofit.py --queries "climate" --time 30 --visualize
+```
+
 The results are written to the directory specified by `output_directory` in the
 configuration.
 

--- a/makesentsofit.py
+++ b/makesentsofit.py
@@ -338,11 +338,14 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
             
             # Export based on requested formats
             exported_files = []
+            analysis_json_path = None
+            user_network_json_path = None
             
             if 'json' in format_list:
                 print("\n📄 Exporting JSON...")
                 json_data = formatter.format_for_json(export_context)
                 filepath = writer.write_json(json_data, output)
+                analysis_json_path = filepath
                 exported_files.append(filepath)
                 print(f"  ✓ Created: {filepath.name}")
             
@@ -423,6 +426,7 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
                     json_path = writer.write_json(
                         json_data, f"{output}_user_network"
                     )
+                    user_network_json_path = json_path
                     exported_files.append(json_path)
                     user_network.create_plotly_network_viz(
                         export_context["posts"],
@@ -511,6 +515,10 @@ def main(queries, time, platforms, output, format, visualize, verbose, config, l
                     if click.confirm(f"\nOpen {file_type} in browser?"):
                         import webbrowser
                         webbrowser.open(f"file://{target_file.absolute()}")
+
+                    if analysis_json_path and click.confirm("Launch interactive dashboard?"):
+                        from src.dashboard import launch_dashboard
+                        launch_dashboard(analysis_json_path, user_network_json_path)
             
             print("\n✨ Thank you for using MakeSenseOfIt!")
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,7 @@ wordcloud==1.9.2
 plotly==5.18.0
 dash==2.15.0
 openai==1.30.1
+streamlit==1.30.0
+streamlit-plotly-events==0.0.6
+python-louvain==0.16
+scikit-learn==1.3.2

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,15 @@
+"""Streamlit dashboard package for MakeSenseOfIt."""
+
+from pathlib import Path
+from . import streamlit_app
+
+
+def launch_dashboard(analysis_file: Path, user_network_file: Path | None = None) -> None:
+    """Launch the Streamlit dashboard as a subprocess."""
+    import subprocess
+
+    args = ["streamlit", "run", str(Path(__file__).parent / "streamlit_app.py"), "--", "--analysis", str(analysis_file)]
+    if user_network_file:
+        args += ["--user-network", str(user_network_file)]
+    subprocess.Popen(args)
+

--- a/src/dashboard/components/network_viz.py
+++ b/src/dashboard/components/network_viz.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import networkx as nx
+import plotly.graph_objects as go
+import streamlit as st
+
+
+NODE_COLORS = {
+    "user": "#1f77b4",
+    "subreddit": "#ff7f0e",
+    "topic": "#2ca02c",
+}
+
+
+def draw_network(graph: nx.Graph) -> None:
+    """Render the network graph using Plotly and Streamlit."""
+    if graph.number_of_nodes() == 0:
+        st.info("No data available for this selection")
+        return
+
+    pos = nx.spring_layout(graph, k=0.6, seed=42)
+
+    edge_x, edge_y = [], []
+    for n1, n2 in graph.edges():
+        x0, y0 = pos[n1]
+        x1, y1 = pos[n2]
+        edge_x.extend([x0, x1, None])
+        edge_y.extend([y0, y1, None])
+
+    edge_trace = go.Scatter(
+        x=edge_x,
+        y=edge_y,
+        line=dict(width=0.5, color="#aaa"),
+        hoverinfo="none",
+        mode="lines",
+    )
+
+    node_x, node_y, node_text, node_color = [], [], [], []
+    for node, data in graph.nodes(data=True):
+        x, y = pos[node]
+        node_x.append(x)
+        node_y.append(y)
+        node_text.append(node)
+        node_color.append(NODE_COLORS.get(data.get("node_type", "user"), "#1f77b4"))
+
+    node_trace = go.Scatter(
+        x=node_x,
+        y=node_y,
+        mode="markers+text",
+        hoverinfo="text",
+        text=node_text,
+        textposition="bottom center",
+        marker=dict(
+            size=12,
+            color=node_color,
+            line=dict(width=1, color="white"),
+            opacity=0.9,
+        ),
+    )
+
+    fig = go.Figure(data=[edge_trace, node_trace])
+    fig.update_layout(
+        margin=dict(l=20, r=20, t=20, b=20),
+        height=600,
+        plot_bgcolor="white",
+        showlegend=False,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+

--- a/src/dashboard/components/sidebar.py
+++ b/src/dashboard/components/sidebar.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+
+def apply_filters(df: pd.DataFrame) -> pd.DataFrame:
+    """Build sidebar controls and filter the dataframe."""
+    if df.empty:
+        st.sidebar.info("No data loaded")
+        return df
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    min_date = df["timestamp"].min()
+    max_date = df["timestamp"].max()
+
+    st.sidebar.header("Filters")
+    start, end = st.sidebar.date_input(
+        "Date range",
+        [min_date.date(), max_date.date()],
+    )
+
+    score_min, score_max = st.sidebar.slider(
+        "Sentiment score",
+        -1.0,
+        1.0,
+        (-1.0, 1.0),
+        step=0.1,
+    )
+
+    mask = (
+        (df["timestamp"] >= pd.to_datetime(start))
+        & (df["timestamp"] <= pd.to_datetime(end))
+    )
+    if "sentiment" in df.columns and isinstance(df.loc[0, "sentiment"], dict):
+        scores = df["sentiment"].apply(lambda x: x.get("score", 0))
+    else:
+        scores = df.get("sentiment_score", pd.Series([0] * len(df)))
+    mask &= scores.between(score_min, score_max)
+
+    return df[mask]
+

--- a/src/dashboard/config/dashboard_config.py
+++ b/src/dashboard/config/dashboard_config.py
@@ -1,0 +1,11 @@
+DASHBOARD_CONFIG = {
+    "network": {
+        "layout_algorithm": "spring",
+        "max_nodes": 1000,
+    },
+    "filters": {
+        "default_time_window": 365,
+        "default_sentiment_range": (-1.0, 1.0),
+    },
+}
+

--- a/src/dashboard/data/loader.py
+++ b/src/dashboard/data/loader.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data(ttl=3600)
+def load_analysis(path: str | Path) -> pd.DataFrame:
+    path = Path(path)
+    if not path.exists():
+        return pd.DataFrame()
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    # If the JSON has top-level "posts" key, use that
+    if isinstance(data, dict) and "posts" in data:
+        data = data["posts"]
+    return pd.DataFrame(data)
+
+
+@st.cache_data(ttl=3600)
+def load_user_network(path: str | Path) -> Dict[str, Any]:
+    path = Path(path)
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+

--- a/src/dashboard/data/network_builder.py
+++ b/src/dashboard/data/network_builder.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+import pandas as pd
+
+
+def _increment_edge(G: nx.Graph, n1: Any, n2: Any) -> None:
+    if G.has_edge(n1, n2):
+        G[n1][n2]["weight"] += 1
+    else:
+        G.add_edge(n1, n2, weight=1)
+
+
+def build_triangular_network(df: pd.DataFrame) -> nx.Graph:
+    """Create user-subreddit-topic network graph."""
+    G = nx.Graph()
+    if df.empty:
+        return G
+
+    for _, row in df.iterrows():
+        user = row.get("author")
+        subreddit = row.get("subreddit") or row.get("metadata", {}).get("subreddit")
+        topic = row.get("query") or row.get("topic")
+
+        if user:
+            G.add_node(user, node_type="user")
+        if subreddit:
+            G.add_node(subreddit, node_type="subreddit")
+        if topic:
+            G.add_node(topic, node_type="topic")
+
+        if user and subreddit:
+            _increment_edge(G, user, subreddit)
+        if user and topic:
+            _increment_edge(G, user, topic)
+        if subreddit and topic:
+            _increment_edge(G, subreddit, topic)
+
+    return G
+

--- a/src/dashboard/streamlit_app.py
+++ b/src/dashboard/streamlit_app.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import streamlit as st
+
+from .data.loader import load_analysis, load_user_network
+from .data.network_builder import build_triangular_network
+from .components.sidebar import apply_filters
+from .components.network_viz import draw_network
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MakeSenseOfIt Dashboard")
+    parser.add_argument("--analysis", type=Path, required=True, help="Path to analysis JSON")
+    parser.add_argument("--user-network", type=Path, default=None, help="Path to user network JSON")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    st.set_page_config(page_title="MakeSenseOfIt Dashboard", layout="wide")
+    st.title("MakeSenseOfIt Interactive Dashboard")
+
+    df = load_analysis(args.analysis)
+    user_network = load_user_network(args.user_network) if args.user_network else {}
+
+    filtered_df = apply_filters(df)
+    graph = build_triangular_network(filtered_df)
+
+    st.subheader("Network Visualization")
+    draw_network(graph)
+
+    st.subheader("Data Preview")
+    st.dataframe(filtered_df, use_container_width=True)
+
+    if user_network:
+        st.subheader("User Network Metrics")
+        st.json(user_network)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- integrate Streamlit dashboard with modern network visualisation
- install dashboard dependencies
- launch dashboard from the CLI after analysis
- rework Reddit scraper to always use PRAW and simplify subreddit priorities
- document dashboard usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d826c3f688324bc9b8c20807c9863

## Summary by Sourcery

Introduce an interactive Streamlit dashboard for visualizing analysis results and simplify the Reddit scraper to always use PRAW with streamlined logic.

New Features:
- Add a Streamlit-based dashboard with network visualization, filters, and data preview.
- Enable launching the interactive dashboard automatically from the CLI when visualization is requested.

Enhancements:
- Refactor Reddit scraper to require PRAW, remove JSON API fallback, and simplify credential handling.
- Simplify subreddit prioritization logic to use provided subreddits before defaults.

Build:
- Add new dashboard dependencies (streamlit, streamlit-plotly-events, python-louvain, scikit-learn) to requirements.txt

Documentation:
- Document dashboard usage and launch instructions in the README.